### PR TITLE
Fix for "uninitialized constant Spree::RansackableAttributes"

### DIFF
--- a/lib/spree_shared/spree_preferences_extensions.rb
+++ b/lib/spree_shared/spree_preferences_extensions.rb
@@ -9,6 +9,7 @@ require Spree::Core::Engine.root.join "app/models/spree/preferences/preferable_c
 require Spree::Core::Engine.root.join "app/models/spree/preferences/configuration"
 require Spree::Core::Engine.root.join "app/models/spree/preferences/store"
 
+require Spree::Core::Engine.root.join "app/models/concerns/spree/ransackable_attributes"
 require Spree::Core::Engine.root.join "app/models/spree/base"
 require Spree::Core::Engine.root.join "app/models/spree/preference"
 require Spree::Core::Engine.root.join "app/models/spree/preferences/scoped_store"


### PR DESCRIPTION
Hello, 
without this fix, I have an "uninitialized constant Spree::RansackableAttributes" NameError with Spree 2.4.10.
Maybe there's a better fix than this :)