### PR TITLE
Use `Apartment::Tenant.drop` instead of raw SQL

### DIFF
--- a/lib/spree_shared/tenant_initializer.rb
+++ b/lib/spree_shared/tenant_initializer.rb
@@ -9,8 +9,13 @@ class SpreeShared::TenantInitializer
 
   def create_database
     ActiveRecord::Base.establish_connection #make sure we're talkin' to db
-    ActiveRecord::Base.connection.execute("DROP SCHEMA IF EXISTS #{db_name} CASCADE")
+    drop_tenant_if_exists
     Apartment::Tenant.create db_name
+  end
+
+  def drop_tenant_if_exists
+    Apartment::Tenant.drop db_name
+  rescue Apartment::TenantNotFound
   end
 
   def load_seeds


### PR DESCRIPTION


This PR changes the `TenantInitializer` to use [`Apartment::Tenant.drop`](https://github.com/rails-on-services/apartment/blob/6ce41138337a46829e9a06ff31c7811a7e42aa18/lib/apartment/adapters/abstract_adapter.rb#L62) instead of the raw `DROP SCHEMA IF EXISTS #{db_name} CASCADE` SQL, which only works for PostgreSQL.

This allows the task to be used with MySQL (which has no `CASCADE` option), SQLite3 (which "drops databases" by deleting the DB file), [and other adapters supported by apartment](https://github.com/rails-on-services/apartment/tree/6ce41138337a46829e9a06ff31c7811a7e42aa18/lib/apartment/adapters), besides PostgreSQL.

Fixes #13.

I also think that the task shouldn't drop existing tenants by default, but only if the user passes a "force" flag. But this is a separate issue.